### PR TITLE
コラム投稿機能修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'rubocop', require: false
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,13 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     bcrypt (3.1.16)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -79,6 +85,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    debug_inspector (1.1.0)
     devise (4.8.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -274,6 +281,8 @@ PLATFORMS
 DEPENDENCIES
   actiontext
   active_hash
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/assets/stylesheets/slider-pro.css
+++ b/app/assets/stylesheets/slider-pro.css
@@ -40,6 +40,8 @@
 	position: relative;
 	display: block;
 	border: none;
+	object-fit: scale-down;
+	
 }
 
 .sp-no-js {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,6 +13,7 @@ class PostsController < ApplicationController
   def create
     Post.create(post_params)
     current_admin.posts.create(post_params)
+    redirect_to posts_path
   end
 
   def show
@@ -26,7 +27,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post).permit(:title, :content, :image)
   end
 
   def set_post
@@ -35,7 +36,7 @@ class PostsController < ApplicationController
 
   def move_to_index
     unless admin_signed_in?
-      redirect_to action: index
+      redirect_to action: :index
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   before_action :set_post, only: [:edit, :show]
-  
+  before_action :move_to_index, except: [:index, :show]
+
   def index
     @posts = Post.search(params[:keyword]).order("created_at DESC")
   end
@@ -30,6 +31,12 @@ class PostsController < ApplicationController
 
   def set_post
     @post = Post.find(params[:id])
+  end
+
+  def move_to_index
+    unless admin_signed_in?
+      redirect_to action: index
+    end
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post).permit(:title, :content,:image)
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,6 +12,7 @@ class PostsController < ApplicationController
 
   def create
     Post.create(post_params)
+    binding.pry
     current_admin.posts.create(post_params)
     redirect_to posts_path
   end
@@ -27,7 +28,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content, :image)
+    params.require(:post).permit(:title, :content)
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,6 @@ class PostsController < ApplicationController
 
   def create
     Post.create(post_params)
-    binding.pry
     current_admin.posts.create(post_params)
     redirect_to posts_path
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content,:image)
+    params.require(:post).permit(:title, :content,:image, :genre_id)
   end
 
   def set_post

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:title, :content,:image, :genre_id)
+    params.require(:post).permit(:title, :content,:image, :category_id)
   end
 
   def set_post

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,9 @@
+class Category < ActiveHash::Base
+ self.data = [
+   { id: 1, name: '--' },
+   { id: 2, name: 'カテゴリ1' },
+   { id: 3, name: 'カテゴリ2' },
+   { id: 4, name: 'カテゴリ3' },
+   { id: 5, name: 'カテゴリ4' }
+ ]
+ end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,4 +6,8 @@ class Category < ActiveHash::Base
    { id: 4, name: 'カテゴリ3' },
    { id: 5, name: 'カテゴリ4' }
  ]
+
+ include ActiveHash::Associations
+ has_many :category
+
  end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,9 +1,11 @@
 class Post < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :likes, dependent: :destroy 
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
   has_many :comments
   belongs_to :admin
+  belongs_to :category
 
   has_one_attached :image
   has_rich_text :content

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,7 +15,7 @@ class Post < ApplicationRecord
     validates :content
   end
 
-  validates :genre_id, numericality: { other_than: 1, message: "が空なので登録できません" }
+  validates :category_id, numericality: { other_than: 1, message: "が空なので登録できません" }
 
 
   

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,11 +10,12 @@ class Post < ApplicationRecord
   has_one_attached :image
   has_rich_text :content
 
-
   with_options presence: true do
     validates :title
     validates :content
   end
+
+  validates :genre_id, numericality: { other_than: 1, message: "が空なので登録できません" }
 
 
   

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,9 +23,9 @@ class Post < ApplicationRecord
     end
   end
 
-  def self.search(keryword)
-    if search != ""
-      Post.where('title LIKE(?)', "%#{search}%")
+  def self.search(keyword)
+    if keyword != ""
+      Post.where('title LIKE(?)', "%#{keyword}%")
     else
       Post.all
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,6 +8,8 @@ class Post < ApplicationRecord
   has_rich_text :content
 
   validates :title, presence: true
+
+
   
   def save_tags(savepost_tags)
     savepost_tags.each do |new_name|
@@ -23,4 +25,5 @@ class Post < ApplicationRecord
       Post.all
     end
   end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,12 +2,17 @@ class Post < ApplicationRecord
   has_many :likes, dependent: :destroy 
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
-  belongs_to :admin
   has_many :comments
+  belongs_to :admin
+
   has_one_attached :image
   has_rich_text :content
 
-  validates :title, presence: true
+
+  with_options presence: true do
+    validates :title
+    validates :content
+  end
 
 
   
@@ -18,7 +23,7 @@ class Post < ApplicationRecord
     end
   end
 
-  def self.search(search)
+  def self.search(keryword)
     if search != ""
       Post.where('title LIKE(?)', "%#{search}%")
     else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,6 +82,9 @@
               <li>
                 <%= link_to 'コラム投稿', new_post_path %></li>
               <li>
+                <%= link_to '投稿コラム一覧','#' %>
+              </li>
+              <li>
                 <%= link_to "ログアウト", destroy_admin_session_path, method: :delete%></li>
             </ul>
           </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -23,7 +23,7 @@
       <ul class="works_list">
         <% @posts.each do |post| %>
         <li><span class="works_icon">NEW!</span>
-          <%= link_to image_tag(post.image, class: :mask), post_path(post.id) %>
+          <%= link_to image_tag(post.image, class: 'mask'), post_path(post.id)%>
           <span><%= link_to post.title, post_path(post.id), method: :get %></span>
           <%# <%= post.admin.first_name %>
           <%= l post.created_at, format: :short %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -27,7 +27,7 @@
           <%= link_to image_tag(post.image, class: :mask), post_path(post.id)%>
           <% end %>
           <span><%= link_to post.title, post_path(post.id), method: :get %></span>
-          <%# <%= post.admin.first_name %>
+          <%= post.admin.full_name %>
           <%= l post.created_at, format: :short %>
           <% post.tags.each do |tag| %>
           <%= tag.tag_name %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,6 +24,7 @@
         <% @posts.each do |post| %>
         <li><span class="works_icon">NEW!</span>
           <%  if post.image.attached? %>
+          <% binding.pry %>
           <%= link_to image_tag(post.image, class: 'mask'), post_path(post.id)%>
           <% else %>
           <%= link_to image_tag('logo.png', class: 'mask'), post_path(post.id)%>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -23,8 +23,8 @@
       <ul class="works_list">
         <% @posts.each do |post| %>
         <li><span class="works_icon">NEW!</span>
+
           <%  if post.image.attached? %>
-          <% binding.pry %>
           <%= link_to image_tag(post.image, class: 'mask'), post_path(post.id)%>
           <% else %>
           <%= link_to image_tag('logo.png', class: 'mask'), post_path(post.id)%>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -23,7 +23,9 @@
       <ul class="works_list">
         <% @posts.each do |post| %>
         <li><span class="works_icon">NEW!</span>
-          <%= link_to image_tag(post.image, class: 'mask'), post_path(post.id)%>
+          <%  if post.image.attached? %>
+          <%= link_to image_tag(post.image, class: :mask), post_path(post.id)%>
+          <% end %>
           <span><%= link_to post.title, post_path(post.id), method: :get %></span>
           <%# <%= post.admin.first_name %>
           <%= l post.created_at, format: :short %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,7 +24,9 @@
         <% @posts.each do |post| %>
         <li><span class="works_icon">NEW!</span>
           <%  if post.image.attached? %>
-          <%= link_to image_tag(post.image, class: :mask), post_path(post.id)%>
+          <%= link_to image_tag(post.image, class: 'mask'), post_path(post.id)%>
+          <% else %>
+          <%= link_to image_tag('logo.png', class: 'mask'), post_path(post.id)%>
           <% end %>
           <span><%= link_to post.title, post_path(post.id), method: :get %></span>
           <%= post.admin.full_name %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -20,6 +20,11 @@
       <%= f.file_field :image %>
     </div>
 
+    <div class="field">カテゴリー選択<br>
+      <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"genre-select"}) %>
+    </div>
+
+
     <div class="field">
       <%= f.label :tag_ids, 'タグ'%>
       <%= f.text_field :tag_ids, placeholder: 'タグを入力してください' %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -21,7 +21,7 @@
     </div>
 
     <div class="field">カテゴリー選択<br>
-      <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"genre-select"}) %>
+      <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {}) %>
     </div>
 
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -16,8 +16,12 @@
       <%= f.text_field :title, placeholder: "タイトルを入力してください" %>
     </div>
 
+    <div class="field">サムネイル画像<br>
+      <%= f.file_field :image %>
+    </div>
+
     <div class="field">
-      <%= f.label :tag_ids, "タグ"%>
+      <%= f.label :tag_ids, 'タグ'%>
       <%= f.text_field :tag_ids, placeholder: 'タグを入力してください' %>
       <%= f.collection_check_boxes :post_tags, Tag.all, :id, :tag_name %>
     </div>

--- a/db/migrate/20210514111917_devise_create_admins.rb
+++ b/db/migrate/20210514111917_devise_create_admins.rb
@@ -38,8 +38,8 @@ class DeviseCreateAdmins < ActiveRecord::Migration[6.0]
       t.timestamps null: false
     end
 
-    # add_index :admins, :email,                unique: true
-    # add_index :admins, :reset_password_token, unique: true
+    add_index :admins, :email,                unique: true
+    add_index :admins, :reset_password_token, unique: true
     # add_index :admins, :confirmation_token,   unique: true
     # add_index :admins, :unlock_token,         unique: true
   end

--- a/db/migrate/20210515073516_create_posts.rb
+++ b/db/migrate/20210515073516_create_posts.rb
@@ -1,8 +1,9 @@
 class CreatePosts < ActiveRecord::Migration[6.0]
   def change
     create_table :posts do |t|
-      t.string :title, null: false
-      t.references :admin, foreign_key: true, dependent: :destroy
+      t.string     :title       , null: false
+      t.references :admin       , foreign_key: true, dependent: :destroy
+      t.integer    :category_id , null: false
       t.timestamps
     end
   end

--- a/db/migrate/20210515073516_create_posts.rb
+++ b/db/migrate/20210515073516_create_posts.rb
@@ -2,7 +2,7 @@ class CreatePosts < ActiveRecord::Migration[6.0]
   def change
     create_table :posts do |t|
       t.string :title, null: false
-      t.references :admin, foreign_key: true
+      t.references :admin, foreign_key: true, dependent: :destory
       t.timestamps
     end
   end

--- a/db/migrate/20210515073516_create_posts.rb
+++ b/db/migrate/20210515073516_create_posts.rb
@@ -2,7 +2,7 @@ class CreatePosts < ActiveRecord::Migration[6.0]
   def change
     create_table :posts do |t|
       t.string :title, null: false
-      t.references :admin, foreign_key: true, dependent: :destory
+      t.references :admin, foreign_key: true, dependent: :destroy
       t.timestamps
     end
   end

--- a/db/migrate/20210524111917_devise_create_admins.rb
+++ b/db/migrate/20210524111917_devise_create_admins.rb
@@ -38,8 +38,8 @@ class DeviseCreateAdmins < ActiveRecord::Migration[6.0]
       t.timestamps null: false
     end
 
-    add_index :admins, :email,                unique: true
-    add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :email,                unique: true
+    # add_index :admins, :reset_password_token, unique: true
     # add_index :admins, :confirmation_token,   unique: true
     # add_index :admins, :unlock_token,         unique: true
   end

--- a/db/migrate/20210629002550_create_contacts.rb
+++ b/db/migrate/20210629002550_create_contacts.rb
@@ -9,7 +9,6 @@ class CreateContacts < ActiveRecord::Migration[6.0]
       t.string  :address
       t.text    :message      ,null: false
       t.integer :inquiry_id   ,null:false
-
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,8 +53,6 @@ ActiveRecord::Schema.define(version: 2021_07_11_060135) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_admins_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,6 +53,8 @@ ActiveRecord::Schema.define(version: 2021_07_11_060135) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -96,6 +98,7 @@ ActiveRecord::Schema.define(version: 2021_07_11_060135) do
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.bigint "admin_id"
+    t.integer "category_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["admin_id"], name: "index_posts_on_admin_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Admin.create(
+  email: 'test@testtest.com',
+  first_name: 'テスト',
+  last_name: 'たろう',
+  password: '0000abcd'
+)


### PR DESCRIPTION
やりたいこと

・ログイン者以外投稿ページに直接遷移させないようにする
・カテゴリ分けができるようにして、カテゴリごとの一覧ページに振り分けられるようにする
・全カテゴリ一覧ページに表示できるようにする
・タグを登録したら、そのタグを他のコラムでも使えるようにする
・投稿者の氏名を詳細ページと一覧ページで表示できるようにする
・いいねボタンの数を一覧ページでも見れるようにする
・SNSシェアさせる設定
・画像がなくても投稿できるようにする
